### PR TITLE
On 64-bit OSs compiling Mupen64bit requires more swap

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -152,7 +152,11 @@ function sources_mupen64plus() {
 }
 
 function build_mupen64plus() {
-    rpSwap on 750
+    if isPlatform "64bit"; then
+        rpSwap on 2048
+    else
+        rpSwap on 750
+    fi
 
     local dir
     local params=()

--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -53,6 +53,12 @@ function build_lr-mupen64plus-next() {
         params+=(FORCE_GLES=1)
     fi
 
+    if isPlatform "64bit"; then
+        rpSwap on 2048
+    else
+        rpSwap on 750
+    fi
+
     # use a custom core name to avoid core option name clashes with lr-mupen64plus
     params+=(CORE_NAME=mupen64plus-next)
     make "${params[@]}" clean
@@ -63,6 +69,8 @@ function build_lr-mupen64plus-next() {
     else
         make "${params[@]}"
     fi
+
+    rpSwap off
 
     md_ret_require="$md_build/mupen64plus_next_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -52,7 +52,11 @@ function sources_lr-mupen64plus() {
 }
 
 function build_lr-mupen64plus() {
-    rpSwap on 750
+    if isPlatform "64bit"; then
+        rpSwap on 2048
+    else
+        rpSwap on 750
+    fi
     local params=()
     if isPlatform "videocore"; then
         params+=(platform="$__platform")


### PR DESCRIPTION
On 64-bit OSs compiling Mupen64bit requires more swap

Compiling on 64bit requires more memory