### PR TITLE
runcommand: add new 'kms' videomode utility

### DIFF
--- a/scriptmodules/supplementary/kmsxx.sh
+++ b/scriptmodules/supplementary/kmsxx.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="kmsxx"
+rp_module_desc="library and utilities for Linux kernel mode setting"
+rp_module_licence="MPL2 https://raw.githubusercontent.com/cmitu/kmsxx/master/LICENSE"
+rp_module_repo="git https://github.com/cmitu/kmsxx retropie"
+rp_module_section="depends"
+rp_module_flags=""
+
+function depends_kmsxx() {
+    getDepends meson ninja-build libdrm-dev libfmt-dev pkg-config
+}
+
+function sources_kmsxx() {
+    gitPullOrClone
+}
+
+function build_kmsxx() {
+    rm -fr build
+    meson setup --prefix="$md_inst" -Dbuildtype=release -Ddefault_library=static -Domap=disabled -Dpykms=disabled -Dkmscube=false build
+    ninja -C build
+
+    md_ret_require="$md_build/build/utils/kmsprint-rp"
+}
+
+function install_kmsxx() {
+    md_ret_files=(
+        build/utils/kmsprint-rp
+        build/utils/kmsprint
+        build/utils/kmsview
+        build/utils/kmsblank
+        build/utils/fbtest
+    )
+}

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -52,7 +52,7 @@ function install_bin_runcommand() {
 
     # needed for KMS modesetting (debian buster or later only)
     if [[ "$__os_debian_ver" -ge 10 ]]; then
-        rp_installModule "mesa-drm" "_autoupdate_"
+        rp_installModule "kmsxx" "_autoupdate_"
     fi
 
     md_ret_require="$md_inst/runcommand.sh"

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -90,7 +90,7 @@ JOY2KEY="$ROOTDIR/admin/joy2key/joy2key"
 
 # modesetting tools
 TVSERVICE="/opt/vc/bin/tvservice"
-KMSTOOL="$ROOTDIR/supplementary/mesa-drm/modetest"
+KMSTOOL="$ROOTDIR/supplementary/kmsxx/kmsprint-rp"
 XRANDR="xrandr"
 
 source "$ROOTDIR/lib/inifuncs.sh"
@@ -129,7 +129,7 @@ function get_config() {
     if [[ -n "$DISPLAY" ]] && $XRANDR &>/dev/null; then
         HAS_MODESET="x11"
     # copy kms tool output to global variable to avoid multiple invocations
-    elif [[ -c /dev/dri/card0 ]] && KMS_BUFFER="$($KMSTOOL -r 2>/dev/null)"; then
+    elif [[ -c /dev/dri/card0 ]] && KMS_BUFFER="$($KMSTOOL 2>/dev/null)"; then
         HAS_MODESET="kms"
     elif [[ -f "$TVSERVICE" ]]; then
         HAS_MODESET="tvs"
@@ -241,37 +241,23 @@ function get_all_tvs_modes() {
 
 function get_all_kms_modes() {
     declare -Ag MODE
-    local default_mode="$(echo "$KMS_BUFFER" | grep -Em1 "^Mode:.*(driver|userdef).*crtc")"
-    local crtc="$(echo "$default_mode" | awk '{ print $(NF-1) }')"
-    local crtc_encoder="$(echo "$KMS_BUFFER" | grep "Encoder map:" | awk -v crtc="$crtc" '$5 == crtc { print $3 }')"
-
-    local info
-    local line
-    local mode_id
+    default_mode="$(echo "$KMS_BUFFER" | grep -Em1 "^Mode: [0-9]+ crtc")"
+    crtc="$(echo "$default_mode" | cut -d' ' -f  4)"
+    crtc_encoder="$(echo "$KMS_BUFFER" | grep "Encoder map:" | awk -v crtc="$crtc" '$5 == crtc { print $3 }')"
 
     # add default mode as fallback in case real mode cannot be mapped
-    MODE[def-def]="$(echo "$default_mode" | awk '{--NF --NF --NF; print}' | cut -c7-)"
+    MODE[def-def]="$(echo "$default_mode" | cut -d' ' -f5-)"
 
-    while read -r line; do
-        # encoder id
-        encoder_id="$(echo "$line" | awk '{ print $(NF-1) }')"
+    # parse only the video modes connected to the current active crtc
+    while read -r mode_str mode_id con encoder_id info; do
+           # we only need 2nd column (mode index) and the 5+ columns (resolution info)
+           # populate resolution info into arrays (using mapped crtc encoder value)
+           MODE_ID+=($crtc-$mode_id)
+           MODE[$crtc-$mode_id]="$info"
 
-        # only match encoders that are linked to the currently active crtc
-        if [[ "$encoder_id" == "$crtc_encoder" ]]; then
-            # mode id
-            mode_id="$(echo "$line" | awk '{ print $NF }')"
-
-            # make output more human-readable
-            info="$(echo "$line" | awk '{--NF --NF --NF; print}' | cut -c7-)"
-
-            # populate resolution into arrays (using mapped crtc encoder value)
-            MODE_ID+=($crtc-$mode_id)
-            MODE[$crtc-$mode_id]="$info"
-
-            # if string matches default mode, add a special mapped entry
-            [[ "$default_mode" =~ "$info" ]] && MODE[map-map]="$crtc $mode_id"
-        fi
-    done < <(echo "$KMS_BUFFER" | grep "Mode:" | grep "connector")
+           # if string matches default mode, add a special mapped entry
+           [[ "$default_mode" =~ "$info" ]] && MODE[map-map]="$crtc $mode_id"
+    done < <(echo "$KMS_BUFFER" | grep -E "^Mode: [0-9]+ connector $crtc_encoder")
 }
 
 function get_all_x11_modes()
@@ -373,7 +359,7 @@ function get_kms_mode_info() {
         fi
     fi
 
-    # split resolution
+    # split resolution (1st column)
     status=(${MODE[${mode_id[0]}-${mode_id[1]}]/x/ })
 
     # get crtc id
@@ -384,13 +370,14 @@ function get_kms_mode_info() {
 
     # get mode resolution
     mode_info[2]="${status[0]}"
-    mode_info[3]="${status[1]}"
+    # yres may have an ending 'i'(nterlace) flag
+    mode_info[3]="${status[1]/i/}"
 
-    # get aspect ratio
+    # get aspect ratio (5th column)
     mode_info[4]="${status[5]}"
 
-    # get refresh rate
-    mode_info[5]="${status[3]}"
+    # get refresh rate (4th column, remove surrounding brackets)
+    mode_info[5]="${status[4]//[()]/}"
 
     echo "${mode_info[@]}"
 }
@@ -1088,7 +1075,8 @@ function retroarch_append_config() {
     touch "$conf"
     iniConfig " = " '"' "$conf"
 
-    if [[ -n "$HAS_MODESET" && "${MODE_CUR[5]}" -gt 0 ]]; then
+    # strip any suffix decimals appearing in refresh rate, just for comparison
+    if [[ -n "$HAS_MODESET" && "${MODE_CUR[5]%.*}" -gt 0 ]]; then
         # set video_refresh_rate in our config to the same as the screen refresh
         iniSet "video_refresh_rate" "${MODE_CUR[5]}"
     fi


### PR DESCRIPTION
Replaced the `mesa-drm` scriptmodule and the `modetest` utility with a new program, based on the [kmsxx](https://github.com/tomba/kmsxx) project.

1. Added a new scriptmodule to install the new modesetting utilities:

 * kmsblank - blank screen(s)
 * kmstest - set modes and planes and show test pattern on crtcs/planes, and test page flips
 * kmsprint(-rp) - print information about DRM objects (connectors, encoders, video modes, crtcs)
 * fbtest - show info about the console framebuffer

It's based on https://github.com/tomba/kmsxx, forked to add a custom `kmsprint-rp` utility which we can use in `runcommand` instead of `modetest`.

Advantages over `modetest`:

 - it's based on a simpler standalone project and not part of Mesa, less code.
 - it's has a modularized C++ API for working with Cards/Encoders/Connectors/CRTCs/etc, modeled after the DRM API entities
 - works with any DRM/KMS card and doesn't have any card specific code like `modetest`
 - it's faster than modetest (both when KMS is enabled or disabled)
 - can print the analog video modes when the 'composite' output is enabled for RPI. I think `modetest` can be modified to support it, but with `kmsxx` is working without any special handling.

 Note that a Debian package of the `kmsxx` upstream project is packaged in Rasberry PI OS (as `kms++-utils`), but it's not part of Debian. Packaging it as part of RetroPie helps with:
   - integration with `runcommand`, since we can run our own custom query utility
   - resolution switching on other KMS platforms

2. Changes to `runcommand`:

  - replaced `modetest` with `kmsprint-rp`. The format for the modeline printing has changed a bit, to make it easier to parse and integrate the result in `runcommand`. In addition to the rounded/integral refresh rate, there's a new column to show a decimal refresh rate; the _[p|n][h|v]sync_ flags have been reformatted as _[h|v]sync[-|+]_.
  - simplified the modeline parsing for KMS, taking advantage of the new format
  - refresh rate (from KMS modeline) is now be a decimal number (.2f), supported by RetroArch